### PR TITLE
Composer doc for 8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 ## Usage
 
+### Drupal Core 8.8
+
+``composer require --dev webflo/drupal-core-require-dev ~8.8.0``
+
 ### Drupal Core 8.7
 
 ``composer require --dev webflo/drupal-core-require-dev ~8.7.0``


### PR DESCRIPTION
Noticed this was missing the instructions for 8.8 and this PR provides that. Wasn't sure if going agnostic might not be the direction you wanted to go (i.e.):

```
### Drupal Core 8.x

``composer require --dev webflo/drupal-core-require-dev ~8.x.0``
```

